### PR TITLE
Update go-rsyslog-pstats to support custom statsd host and prefix with hostname

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module go-rsyslog-pstats
+
+go 1.16
+
+require github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -32,13 +32,14 @@ func printVersion() {
 }
 
 func printHelp() {
-	fmt.Fprintln(os.Stderr, "go-rsyslog-pstats --port number\n")
+	fmt.Fprintln(os.Stderr, "go-rsyslog-pstats [--host 1.2.3.4] --port number")
 	fmt.Fprintf(os.Stderr, "Parses and forwards rsyslog process stats to a local statsite or statsd process\n\n")
 	flag.PrintDefaults()
 }
 
-func parseConfig() (port string) {
+func parseConfig() (host string, port string) {
 	flag.Usage = printHelp
+	hostAddress := flag.String("host", "localhost", "Statsd host to send metrics to")
 	outPort := flag.String("port", "", "Statsite udp port to connect to")
 	printV := flag.Bool("version", false, "Prints the version string")
 	flag.Parse()
@@ -48,21 +49,21 @@ func parseConfig() (port string) {
 		os.Exit(0)
 	}
 
-	return *outPort
+	return *hostAddress, *outPort
 }
 
 func main() {
-	outPort := parseConfig()
+	hostAddress, outPort := parseConfig()
 
 	in := bufio.NewReader(os.Stdin)
 
 	if outPort == "" {
-		el.Println("No port was provided\n")
+		el.Println("No port was provided")
 		printHelp()
 		os.Exit(1)
 	}
 
-	udpAddr, err := net.ResolveUDPAddr("udp", "localhost:"+outPort)
+	udpAddr, err := net.ResolveUDPAddr("udp", hostAddress+":"+outPort)
 	if err != nil {
 		el.Fatal("Could not resolve address", err)
 	}

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"strings"
 )
 
 const (
@@ -133,7 +134,10 @@ func findNums(prefix string, kvs map[string]interface{}, out io.Writer) {
 			el.Println("Error determining hostname", err)
 		}
 
-		_, err = fmt.Fprintf(out, hostname+".rsyslog.%v.%v:%d|g\n", prefix, sanitizeKey(k), int(vf))
+		// Replace periods with hyphens for graphite compatbility
+		hostnameFormatted := strings.Replace(hostname, ".", "-", -1)
+
+		_, err = fmt.Fprintf(out, "rsyslog."+hostnameFormatted+".%v.%v:%d|g\n", prefix, sanitizeKey(k), int(vf))
 		if err != nil {
 			el.Println("Error while writing", err)
 		}

--- a/main.go
+++ b/main.go
@@ -135,7 +135,7 @@ func findNums(prefix string, kvs map[string]interface{}, out io.Writer) {
 		}
 
 		// Replace periods with hyphens for graphite compatbility
-		hostnameFormatted := strings.Replace(hostname, ".", "-", -1)
+		hostnameFormatted := strings.ReplaceAll(hostname, ".", "-")
 
 		_, err = fmt.Fprintf(out, "rsyslog."+hostnameFormatted+".%v.%v:%d|g\n", prefix, sanitizeKey(k), int(vf))
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -128,7 +128,12 @@ func findNums(prefix string, kvs map[string]interface{}, out io.Writer) {
 			continue
 		}
 
-		_, err := fmt.Fprintf(out, "rsyslog.%v.%v:%d|g\n", prefix, sanitizeKey(k), int(vf))
+		hostname, err := os.Hostname()
+		if err != nil {
+			el.Println("Error determining hostname", err)
+		}
+
+		_, err = fmt.Fprintf(out, hostname+".rsyslog.%v.%v:%d|g\n", prefix, sanitizeKey(k), int(vf))
 		if err != nil {
 			el.Println("Error while writing", err)
 		}


### PR DESCRIPTION
I had to make a few changes to the original code for our needs

- support passing in host param as statsd daemon
- prefix metrics with hostname otherwise we don't know which server is sending the metric